### PR TITLE
Allow renamed classes (proposal one)

### DIFF
--- a/rule.js
+++ b/rule.js
@@ -127,7 +127,7 @@ module.exports = {
       },
 
       MemberExpression(node) {
-        if (node.object.type === 'Identifier' && node.object.name === 'classes') {
+        if (node.object.type === 'Identifier') {
           const whichClass = getBasicIdentifier(node.property);
           if (whichClass) {
             usedClasses[whichClass] = true;

--- a/rule.js
+++ b/rule.js
@@ -127,7 +127,7 @@ module.exports = {
       },
 
       MemberExpression(node) {
-        if (node.object.type === 'Identifier') {
+        if (node.object.type === 'Identifier' && node.object.name) {
           const whichClass = getBasicIdentifier(node.property);
           if (whichClass) {
             usedClasses[whichClass] = true;

--- a/test.js
+++ b/test.js
@@ -46,7 +46,34 @@ ruleTester.run('warn-unused-classes', rule, {
     const Component = () => {
       const { classes } = useStyles()
       return <div className={classes.testClass}>test</div>
-    }`
+    }`,
+    `const useStyles = makeStyles()(() => ({
+      testClass: {
+        backgroundColor: 'red'
+      }
+    }))
+    const Component = () => {
+      const { classes: renamedClasses } = useStyles()
+      return <div className={renamedClasses.testClass}>test</div>
+    }`,
+    `const useStylesOne = makeStyles()(() => ({
+      header: {
+        backgroundColor: 'red'
+      }
+    }))
+    const useStylesTwo = makeStyles()(() => ({
+      footer: {
+        backgroundColor: 'blue'
+      }
+    }))
+    const Component = () => {
+      const { classes: classesOne } = useStylesOne();
+      const { classes: classesTwo } = useStylesOne();
+      return <>
+        <div className={classesOne.header}>test</div>
+        <div className={classesTwo.footer}>test</div>
+      </>
+    }`,
   ],
   invalid: [
     {
@@ -118,9 +145,49 @@ ruleTester.run('warn-unused-classes', rule, {
         return <div>test</div>
       }`,
       errors: [{
-        message: 'Class `testClass` is unused'
-      }]
+          message: 'Class `testClass` is unused'
+        }]
     },
-
+    {
+      code: `const useStyles = tss.withName('Component').create({
+        testClass: {
+          backgroundColor: 'red'
+        }
+      })
+      const Component = () => {
+        const { classes: renamedClasses } = useStyles()
+        return <div>test</div>
+      }`,
+      errors: [
+        {
+          message: 'Class `testClass` is unused',
+        },
+      ],
+    },
+    {
+      code: `const useStylesOne = tss.withName('Component').create({
+        header: {
+          backgroundColor: 'red'
+        }
+      })
+      const useStylesTwo = tss.withName('Component').create({
+        footer: {
+          backgroundColor: 'blue'
+        }
+      })
+      const Component = () => {
+        const { classes: classesOne } = useStylesOne()
+        const { classes: classesTwo } = useStylesTwo()
+        return <>
+          <div className={classesOne.header}>test</div>
+          <div>test</div>
+        </>
+      }`,
+      errors: [
+        {
+          message: 'Class `footer` is unused',
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
(This is the first of two proposals to solve the same problem. They are mutually exclusive and proposal two can be found [here](https://github.com/garronej/eslint-plugin-tss-unused-classes/pull/8))

Currently the linter does not test against renamed classes, eg:

```js
const useStylesOne = tss.create({
  header: {
    backgroundColor: "red",
  },
});
const useStylesTwo = tss.create({
  footer: {
    backgroundColor: "blue",
  },
});
const Component = () => {
  const { classes: renamedClassesOne } = useStylesOne();
  const { classes: renamedClassesTwo } = useStylesTwo();
  return (
    <>
      <div className={renamedClassesOne.header}>test</div>
      <div className={renamedClassesTwo.footer}>test</div>
    </>
  );
};
```

The above currently returns false errors for both `header` and `footer`.

This PR removes the check against the `classes` value in the member expression’s name. This should not be a risk because the only member expression identifiers tested are from ‘makeStyles’ call expressions. There may be a few with undefined values for `value.object.name` so we can just check that this value is defined rather than check that this value is equal to ‘classes’.

Relevant tests have been added.