### PR TITLE
Allow renamed classes (proposal two)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 package-lock.json
+.npm

--- a/README.md
+++ b/README.md
@@ -59,5 +59,22 @@ In case of false positive, disabling the warning:
 - For a line: `// eslint-disable-next-line tss-unused-classes/unused-classes`
 - For the entire file: `// eslint-disable-next-line tss-unused-classes/unused-classes`
 
+## Options
 
+By default the linter does not test against renamed classes, eg: 
 
+```js
+const { classes: myClasses } = useStyles();
+```
+
+If you want to enable this then use the `allowRenamedClasses` option in the `.eslintrc.js` file:
+
+```js
+module.exports = {
+  // ...
+  rules: {
+    // ...
+    'tss-unused-classes/unused-classes': ['warn', allowRenamedClasses: true]
+  }
+}
+```

--- a/rule.js
+++ b/rule.js
@@ -131,7 +131,7 @@ module.exports = {
       },
 
       MemberExpression(node) {
-        if (node.object.type === 'Identifier' && (allowRenamedClasses || node.object.name === 'classes')) {
+        if (node.object.type === 'Identifier' && (node.object.name === 'classes' || (allowRenamedClasses && node.object.name))) {
           const whichClass = getBasicIdentifier(node.property);
           if (whichClass) {
             usedClasses[whichClass] = true;

--- a/rule.js
+++ b/rule.js
@@ -30,6 +30,10 @@ module.exports = {
   create: function rule(context) {
     const usedClasses = {};
     const definedClasses = {};
+    const { options = [] } = context;
+    const allowRenamedClasses = options
+      .map((option) => option?.allowRenamedClasses === true)
+      .some((value) => value === true);
 
     return {
       CallExpression(node) {
@@ -127,7 +131,7 @@ module.exports = {
       },
 
       MemberExpression(node) {
-        if (node.object.type === 'Identifier' && node.object.name === 'classes') {
+        if (node.object.type === 'Identifier' && (allowRenamedClasses || node.object.name === 'classes')) {
           const whichClass = getBasicIdentifier(node.property);
           if (whichClass) {
             usedClasses[whichClass] = true;

--- a/test.js
+++ b/test.js
@@ -28,7 +28,6 @@ ruleTester.run('warn-unused-classes', rule, {
       const { classes } = useStyles()
       return <div className={classes.testClass}>test</div>
     }`,
-
     `const useStyles = tss.create(() => ({
       testClass: {
         backgroundColor: 'red'
@@ -46,7 +45,40 @@ ruleTester.run('warn-unused-classes', rule, {
     const Component = () => {
       const { classes } = useStyles()
       return <div className={classes.testClass}>test</div>
-    }`
+    }`,
+    {
+      code: `const useStyles = tss.create({
+        testClass: {
+          "backgroundColor": 'red'
+        }
+      })
+      const Component = () => {
+        const { classes: renamedClasses } = useStyles()
+        return <div className={renamedClasses.testClass}>test</div>
+      }`,
+      options: [{ allowRenamedClasses: true }]
+    },
+    {
+      code: `const useStylesOne = tss.create({
+        header: {
+          "backgroundColor": 'red'
+        }
+      })
+      const useStylesTwo = tss.create({
+        footer: {
+          "backgroundColor": 'blue'
+        }
+      })
+      const Component = () => {
+        const { classes: renamedClassesOne } = useStylesOne();
+        const { classes: renamedClassesTwo } = useStylesTwo()
+        return <>
+          <div className={renamedClassesOne.header}>test</div>
+          <div className={renamedClassesTwo.footer}>test</div>
+        </>
+      }`,
+      options: [{ allowRenamedClasses: true }]
+    }
   ],
   invalid: [
     {
@@ -119,6 +151,44 @@ ruleTester.run('warn-unused-classes', rule, {
       }`,
       errors: [{
         message: 'Class `testClass` is unused'
+      }]
+    },
+    {
+      code: `const useStyles = tss.create({
+        testClass: {
+          "backgroundColor": 'red'
+        }
+      })
+      const Component = () => {
+        const { classes: renamedClasses } = useStyles()
+        return <div className={renamedClasses.testClass}>test</div>
+      }`,
+      errors: [{
+        message: 'Class `testClass` is unused'
+      }]
+    },
+    {
+      code: `const useStylesOne = tss.create({
+        header: {
+          "backgroundColor": 'red'
+        }
+      })
+      const useStylesTwo = tss.create({
+        footer: {
+          "backgroundColor": 'blue'
+        }
+      })
+      const Component = () => {
+        const { classes: renamedClassesOne } = useStylesOne();
+        const { classes: renamedClassesTwo } = useStylesTwo()
+        return <>
+          <div className={renamedClassesOne.header}>test</div>
+          <div>test</div>
+        </>
+      }`,
+      options: [{ allowRenamedClasses: true }],
+      errors: [{
+        message: 'Class `footer` is unused'
       }]
     },
 


### PR DESCRIPTION
(This is the second of two proposals to solve the same problem. They are mutually exclusive and proposal one can be found [here](https://github.com/garronej/eslint-plugin-tss-unused-classes/pull/7))

Currently the linter does not test against renamed classes, eg:

```js
const useStylesOne = tss.create({
  header: {
    backgroundColor: "red",
  },
});
const useStylesTwo = tss.create({
  footer: {
    backgroundColor: "blue",
  },
});
const Component = () => {
  const { classes: renamedClassesOne } = useStylesOne();
  const { classes: renamedClassesTwo } = useStylesTwo();
  return (
    <>
      <div className={renamedClassesOne.header}>test</div>
      <div className={renamedClassesTwo.footer}>test</div>
    </>
  );
};
```

The above currently returns false errors for both `header` and `footer`.

Proposal two adds an optional flag for `allowRenamedClasses` that can be configured in the .eslintrc, eg:

```js
  rules: {
    // ...
    'tss-unused-classes/unused-classes': ['warn', allowRenamedClasses: true]
  }
```

If present and set to `true`, then the member expression’s identifier need only to have a name value and that value does not have to equal ‘classes’. This should not be a risk because the only member expression identifiers tested are from ‘makeStyles’ call expressions. There may be a few with undefined values for `value.object.name` so we can just check that this value is defined rather than check that this value is equal to ‘classes’.

Relevant tests have been added.